### PR TITLE
Mark the plugin as valid for current CLion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginName = jakt-intellij-plugin
 pluginVersion = 0.0.1
 
 pluginSinceBuild = 211
-pluginUntilBuild = 213.*
+pluginUntilBuild = 221.*
 
 platformType = IC
 platformVersion = 2021.1.3


### PR DESCRIPTION
Maybe the `pluginUntilBuild` line can just be removed instead, not
confident on that though.