### PR TITLE
Folding: Fold import lists

### DIFF
--- a/src/main/kotlin/org/serenityos/jakt/folding/JaktBlockFoldingBuilder.kt
+++ b/src/main/kotlin/org/serenityos/jakt/folding/JaktBlockFoldingBuilder.kt
@@ -1,4 +1,4 @@
-package org.serenityos.jakt
+package org.serenityos.jakt.folding
 
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.CustomFoldingBuilder
@@ -12,7 +12,7 @@ import com.intellij.refactoring.suggested.startOffset
 import org.serenityos.jakt.psi.JaktPsiElement
 import org.serenityos.jakt.psi.api.*
 
-class JaktFoldingBuilder : CustomFoldingBuilder() {
+class JaktBlockFoldingBuilder : CustomFoldingBuilder() {
     override fun buildLanguageFoldRegions(
         descriptors: MutableList<FoldingDescriptor>,
         root: PsiElement,

--- a/src/main/kotlin/org/serenityos/jakt/folding/JaktImportFoldingBuilder.kt
+++ b/src/main/kotlin/org/serenityos/jakt/folding/JaktImportFoldingBuilder.kt
@@ -1,0 +1,56 @@
+package org.serenityos.jakt.folding
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.CustomFoldingBuilder
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.api.JaktImport
+import org.serenityos.jakt.psi.api.JaktImportBraceList
+import org.serenityos.jakt.psi.api.JaktVisitor
+
+class JaktImportFoldingBuilder : CustomFoldingBuilder() {
+
+    override fun buildLanguageFoldRegions(
+            descriptors: MutableList<FoldingDescriptor>,
+            root: PsiElement,
+            document: Document,
+            quick: Boolean
+    ) {
+        val visitor = FoldingVisitor(descriptors)
+        PsiTreeUtil.processElements(root) {
+            it.accept(visitor)
+            true
+        }
+    }
+
+    override fun getLanguagePlaceholderText(node: ASTNode, range: TextRange): String {
+        if (node.psi is JaktImport) {
+            val import = node.psi as JaktImport
+            val importCount = import.importBraceList?.importBraceEntryList?.size ?: return "{ ... }"
+            return "{ <$importCount items> }"
+        }
+        return "{ ... }"
+    }
+
+    override fun isRegionCollapsedByDefault(node: ASTNode): Boolean {
+        if (node.psi is JaktImport) {
+            val import = node.psi as JaktImport
+            return import.importBraceList?.text?.contains('\n') ?: false
+        }
+        return false
+    }
+
+    private class FoldingVisitor(private val descriptors: MutableList<FoldingDescriptor>) : JaktVisitor() {
+        override fun visitPsiElement(o: JaktPsiElement) {
+        }
+
+        override fun visitImport(o: JaktImport) {
+            val importBraceList = o.importBraceList ?: return
+            descriptors += FoldingDescriptor(o, importBraceList.textRange)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,10 @@
                 language="Jakt"
                 implementationClass="org.serenityos.jakt.folding.JaktBlockFoldingBuilder"
         />
+        <lang.foldingBuilder
+                language="Jakt"
+                implementationClass="org.serenityos.jakt.folding.JaktImportFoldingBuilder"
+        />
         <lang.documentationProvider
                 language="Jakt"
                 implementationClass="org.serenityos.jakt.render.JaktDocumentationProvider"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,7 +84,7 @@
         />
         <lang.foldingBuilder
                 language="Jakt"
-                implementationClass="org.serenityos.jakt.JaktFoldingBuilder"
+                implementationClass="org.serenityos.jakt.folding.JaktBlockFoldingBuilder"
         />
         <lang.documentationProvider
                 language="Jakt"


### PR DESCRIPTION
This makes imports like this:

```jakt
import typechecker {
    BuiltinType, CheckedBlock, CheckedCall, CheckedExpression,
    CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
    Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId,
    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId,
    CheckedMatchBody, void_type_id,
    CheckedVariable, NumberConstant, CheckedEnumVariant }
```

...appear like this instead, until you click on them:

```jakt
import typechecker { <25 items> }
```

All import lists with more than 1 item are folded by default. This is not the smartest way of doing it, but it works. :^)