### PR TITLE
Add a comptime interpreter

### DIFF
--- a/src/main/kotlin/org/serenityos/jakt/annotations/BasicAnnotator.kt
+++ b/src/main/kotlin/org/serenityos/jakt/annotations/BasicAnnotator.kt
@@ -11,7 +11,7 @@ import com.intellij.refactoring.suggested.startOffset
 import org.serenityos.jakt.JaktTypes
 import org.serenityos.jakt.psi.ancestorOfType
 import org.serenityos.jakt.psi.api.*
-import org.serenityos.jakt.psi.findChildrenOfType
+import org.serenityos.jakt.psi.findChildOfType
 import org.serenityos.jakt.psi.reference.JaktPlainQualifierMixin
 import org.serenityos.jakt.psi.reference.exprAncestor
 import org.serenityos.jakt.psi.reference.hasNamespace
@@ -61,14 +61,14 @@ object BasicAnnotator : JaktAnnotator(), DumbAware {
             is JaktImportBraceEntry -> element.identifier.highlight(Highlights.IMPORT_ENTRY)
             is JaktExternImport -> element.cSpecifier?.highlight(Highlights.KEYWORD_DECLARATION)
             is JaktImport -> {
-                val idents = element.findChildrenOfType(JaktTypes.IDENTIFIER)
-                idents.first().highlight(Highlights.IMPORT_MODULE)
+                element.importTarget.identifier?.highlight(Highlights.IMPORT_MODULE)
 
-                if (idents.size > 1) {
+
+                if (element.keywordAs != null) {
+                    element.findChildOfType(JaktTypes.IDENTIFIER)?.highlight(Highlights.IMPORT_ALIAS)
                     // The 'as' keyword will be highlighted as an operator here without
                     // the annotation
                     element.keywordAs!!.highlight(Highlights.KEYWORD_IMPORT)
-                    idents[1].highlight(Highlights.IMPORT_ALIAS)
                 }
             }
             is JaktArgument -> {

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
@@ -394,6 +394,7 @@ class Interpreter(element: JaktPsiElement) {
             is JaktTupleExpression -> ExecutionResult.Normal(TupleValue(element.expressionList.map { e ->
                 evaluateNonYield(e) { return it }
             }.toMutableList()))
+            is JaktParenExpression -> evaluate(element.expression!!)
 
             /*** STATEMENTS ***/
 

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
@@ -17,8 +17,13 @@ class Interpreter(element: JaktPsiElement) {
         }.map {
             val scope = Scope(null)
             if (it is JaktScope) {
-                for (decl in it.getDeclarations())
-                    scope[decl.name ?: continue] = evaluate(decl)!!
+                for (decl in it.getDeclarations()) {
+                    try {
+                        scope[decl.name ?: continue] = evaluate(decl)!!
+                    } catch (e: Throwable) {
+                        // Ignore and attempt to continue execution
+                    }
+                }
             }
             if (it is JaktFile)
                 initializeGlobalScope(scope)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
@@ -1,6 +1,5 @@
 package org.serenityos.jakt.comptime
 
-import com.intellij.openapi.util.Ref
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.suggested.endOffset
@@ -10,7 +9,6 @@ import org.serenityos.jakt.psi.JaktPsiElement
 import org.serenityos.jakt.psi.JaktScope
 import org.serenityos.jakt.psi.ancestors
 import org.serenityos.jakt.psi.api.*
-import org.serenityos.jakt.psi.caching.comptimeCache
 import org.serenityos.jakt.psi.findChildOfType
 
 class Interpreter(element: JaktPsiElement) {
@@ -57,16 +55,7 @@ class Interpreter(element: JaktPsiElement) {
     // A return value of null indicates the expression is not comptime. An exception being
     // thrown indicates the expression is comptime, but it malformed in some way and cannot
     // be evaluated.
-    fun evaluate(element: JaktPsiElement): ExecutionResult {
-        val cache = element.comptimeCache()
-        cache.resolve<JaktPsiElement, Ref<ExecutionResult>>(element)?.get()?.let { return it }
-
-        val value = evaluateImpl(element)
-        cache.set(element, Ref(value))
-        return value
-    }
-
-    private fun evaluateImpl(element: JaktPsiElement): ExecutionResult {
+    private fun evaluate(element: JaktPsiElement): ExecutionResult {
         return when (element) {
             /*** EXPRESSIONS ***/
 

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
@@ -66,9 +66,9 @@ class Interpreter(element: JaktPsiElement) {
         return when (element) {
             /*** EXPRESSIONS ***/
 
-            is JaktMatchExpression -> TODO()
-            is JaktTryExpression -> TODO()
-            is JaktLambdaExpression -> TODO()
+            is JaktMatchExpression -> TODO("comptime match expressions")
+            is JaktTryExpression -> TODO("comptime try expressions")
+            is JaktLambdaExpression -> TODO("comptime lambdas")
             is JaktAssignmentBinaryExpression -> {
                 val binaryOp = when {
                     element.plusEquals != null -> BinaryOperator.Add
@@ -145,8 +145,8 @@ class Interpreter(element: JaktPsiElement) {
 
                 ExecutionResult.Normal(VoidValue)
             }
-            is JaktThisExpression -> TODO()
-            is JaktFieldAccessExpression -> TODO()
+            is JaktThisExpression -> TODO("comptime this expressions")
+            is JaktFieldAccessExpression -> TODO("comptime field access")
             is JaktRangeExpression -> {
                 val (startExpr, endExpr) = when {
                     element.expressionList.size == 2 -> element.expressionList[0] to element.expressionList[1]
@@ -229,9 +229,9 @@ class Interpreter(element: JaktPsiElement) {
                     else -> BinaryOperator.Modulo
                 },
             )
-            is JaktCastExpression -> TODO()
-            is JaktIsExpression -> TODO()
-            is JaktUnaryExpression -> TODO()
+            is JaktCastExpression -> TODO("comptime casts")
+            is JaktIsExpression -> TODO("comptime is expressions")
+            is JaktUnaryExpression -> TODO("comptime unary expressions")
             is JaktBooleanLiteral -> ExecutionResult.Normal(BoolValue(element.trueKeyword != null))
             is JaktNumericLiteral -> {
                 element.binaryLiteral?.let {
@@ -424,9 +424,9 @@ class Interpreter(element: JaktPsiElement) {
 
                 ExecutionResult.Normal(VoidValue)
             }
-            is JaktWhileStatement -> TODO()
-            is JaktLoopStatement -> TODO()
-            is JaktForStatement -> TODO()
+            is JaktWhileStatement -> TODO("comptime while statements")
+            is JaktLoopStatement -> TODO("comptime loop statements")
+            is JaktForStatement -> TODO("comptime for statements")
             is JaktVariableDeclarationStatement -> {
                 if (element.parenOpen != null) {
                     error(
@@ -440,7 +440,7 @@ class Interpreter(element: JaktPsiElement) {
 
                 ExecutionResult.Normal(VoidValue)
             }
-            is JaktGuardStatement -> TODO()
+            is JaktGuardStatement -> TODO("comptime guard statements")
             is JaktYieldStatement -> ExecutionResult.Yield(evaluateNonYield(element.expression) { return it })
             is JaktBreakStatement -> ExecutionResult.Break
             is JaktContinueStatement -> ExecutionResult.Continue

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Interpreter.kt
@@ -1,0 +1,251 @@
+package org.serenityos.jakt.comptime
+
+import com.intellij.openapi.util.Ref
+import org.serenityos.jakt.JaktFile
+import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.JaktScope
+import org.serenityos.jakt.psi.ancestors
+import org.serenityos.jakt.psi.api.*
+import org.serenityos.jakt.psi.caching.comptimeCache
+
+class Interpreter(element: JaktPsiElement) {
+    var scope: Scope
+
+    init {
+        val outerScopes = element.ancestors().filter {
+            it is JaktFile || it is JaktFunction || it is JaktStructDeclaration || it is JaktBlock
+        }.map {
+            val scope = Scope(null)
+            if (it is JaktScope) {
+                for (decl in it.getDeclarations())
+                    scope[decl.name ?: continue] = evaluate(decl)!!
+            }
+            if (it is JaktFile)
+                initializeGlobalScope(scope)
+            scope
+        }.toList()
+
+        for ((index, scope) in outerScopes.withIndex()) {
+            if (index == 0)
+                continue
+            scope.outer = outerScopes[index - 1]
+        }
+
+        scope = outerScopes.last()
+    }
+
+    fun pushScope(scope: Scope) {
+        this.scope = scope
+    }
+
+    fun popScope() {
+        scope = scope.outer!!
+    }
+
+    // A return value of null indicates the expression is not comptime. An exception being
+    // thrown indicates the expression is comptime, but it malformed in some way and cannot
+    // be evaluated.
+    fun evaluate(element: JaktPsiElement): Value? {
+        val cache = element.comptimeCache()
+        cache.resolve<JaktPsiElement, Ref<Value>>(element)?.let { return it.get() }
+
+        try {
+            val value = evaluateImpl(element)
+            cache.set(element, Ref(value))
+            return value
+        } catch (e: Throwable) {
+            cache.set(element, Ref(null))
+            throw e
+        }
+    }
+
+    private fun evaluateImpl(element: JaktPsiElement): Value? {
+        return when (element) {
+            is JaktBooleanLiteral -> BoolValue(element.trueKeyword != null)
+            is JaktNumericLiteral -> {
+                element.binaryLiteral?.let {
+                    return IntegerValue(it.text.toLong(2))
+                }
+
+                element.octalLiteral?.let {
+                    return IntegerValue(it.text.toLong(8))
+                }
+
+                element.hexLiteral?.let {
+                    return IntegerValue(it.text.toLong(16))
+                }
+
+                val decimalText = element.decimalLiteral!!.text
+                return if ("." in decimalText) {
+                    FloatValue(decimalText.toDouble())
+                } else IntegerValue(decimalText.toLong(10))
+            }
+            is JaktLiteral -> {
+                element.byteCharLiteral?.let {
+                    return ByteCharValue(it.text[2].code.toByte())
+                }
+
+                element.charLiteral?.let {
+                    return CharValue(it.text.single())
+                }
+
+                return StringValue(element.stringLiteral!!.text.drop(1).dropLast(1))
+            }
+            is JaktPlainQualifierExpression -> {
+                val qualifier = element.plainQualifier
+
+                val parts = generateSequence(qualifier) { it.plainQualifier }
+                    .map { it.identifier.text }
+                    .toMutableList()
+                    .asReversed()
+
+                var value: Value? = scope[parts[0]]
+                parts.removeFirst()
+
+                for (part in parts)
+                   value = (value as StructValue)[part]
+
+                value!!
+            }
+            is JaktTupleExpression -> TupleValue(element.expressionList.map { evaluate(it)!! })
+            is JaktArrayExpression -> {
+                element.elementsArrayBody?.let {  body ->
+                    return ArrayValue(body.expressionList.map { evaluate(it)!! })
+                }
+
+                val body = element.sizedArrayBody!!
+                val value = evaluate(body.expressionList[0])!!
+                val size = evaluate(body.expressionList[1])!!
+                check(size is IntegerValue)
+                ArrayValue((0 until size.value).map { value })
+            }
+            is JaktSetExpression -> SetValue(element.expressionList.map { evaluate(it)!! }.toSet())
+            is JaktDictionaryExpression -> DictionaryValue(
+                element.dictionaryElementList.associate {
+                    evaluate(it.expressionList[0])!! to evaluate(it.expressionList[1])!!
+                }
+            )
+            is JaktFunction -> {
+                val parameters = element.parameterList.parameterList.map { param ->
+                    FunctionValue.Parameter(
+                        param.identifier.text,
+                        param.expression?.let { evaluate(it)!! }
+                    )
+                }
+
+                UserFunctionValue(parameters, element.block ?: element.expression!!)
+            }
+            is JaktCallExpression -> {
+                val target = evaluate(element.expression)!!
+                check(target is FunctionValue)
+
+                val args = element.argumentList.argumentList.map { evaluate(it.expression)!! }
+                check(args.size in target.validParamCount)
+
+                target.call(this, getThisValue(element.expression), args)
+            }
+            is JaktVariableDeclarationStatement -> {
+                if (element.parenOpen != null)
+                    TODO()
+
+                val rhs = evaluate(element.expression)!!
+                val name = element.variableDeclList[0].name!!
+                scope[name] = rhs
+                VoidValue
+            }
+            is JaktBlock -> {
+                pushScope(Scope(scope))
+                element.statementList.forEach(::evaluate)
+                popScope()
+                VoidValue
+            }
+            is JaktIfStatement -> {
+                val canBeExpr = element.canBeExpr
+                val condition = evaluate(element.expression)!!
+                check(condition is BoolValue)
+
+                if (condition.value) {
+                    evaluate(element.block).let {
+                        if (canBeExpr) it else VoidValue
+                    }
+                } else {
+                    element.ifStatement?.let(::evaluate)
+                        ?: element.elseBlock?.let(::evaluate)
+                        ?: VoidValue
+                }
+            }
+            is JaktAccessExpression -> {
+                val target = evaluate(element.expression)!!
+                if (element.dotQuestionMark != null)
+                    TODO()
+                if (element.decimalLiteral != null) {
+                    (target as TupleValue).values[element.decimalLiteral!!.text.toInt()]
+                } else {
+                    (target as StructValue)[element.identifier!!.text]
+                }
+            }
+            is JaktReturnStatement -> throw ReturnException(element.expression?.let { evaluate(it)!! })
+            is JaktExpressionStatement -> {
+                evaluate(element.expression)
+                VoidValue
+            }
+
+            else -> TODO("${element::class.java} it not handled by the Interpreter")
+        }
+    }
+
+    private fun getThisValue(expression: JaktExpression): Value? {
+        return when (expression) {
+            is JaktAccessExpression -> evaluate(expression.expression)!!
+            is JaktFieldAccessExpression -> (scope as FunctionScope).thisBinding!!
+            is JaktIndexedAccessExpression -> evaluate(expression.expressionList.first())!!
+            else -> null
+        }
+    }
+
+    private fun initializeGlobalScope(scope: Scope) {
+        scope.initialize("StringBuilder", StringBuilderStruct)
+    }
+
+    open class Scope(var outer: Scope?) {
+        protected val bindings = mutableMapOf<String, Value>()
+
+        operator fun contains(name: String) = name in bindings
+
+        operator fun get(name: String): Value? = bindings[name] ?: outer?.get(name)
+
+        operator fun set(name: String, value: Value) {
+            var scope: Scope? = this
+
+            while (scope != null) {
+                if (name in scope) {
+                    scope[name] = value
+                    return
+                }
+                scope = scope.outer
+            }
+
+            initialize(name, value)
+        }
+
+        fun initialize(name: String, value: Value) {
+            bindings[name] = value
+        }
+    }
+
+    class FunctionScope(outer: Scope?, val thisBinding: Value?) : Scope(outer) {
+        fun argument(name: String) = bindings[name]!!
+    }
+
+    abstract class FlowException : Error()
+
+    class ReturnException(val value: Value?) : FlowException()
+
+    class YieldException(val value: Value?) : FlowException()
+
+    companion object {
+        fun evaluate(element: JaktPsiElement): Value? {
+            return Interpreter(element).evaluate(element)
+        }
+    }
+}

--- a/src/main/kotlin/org/serenityos/jakt/comptime/InterpreterException.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/InterpreterException.kt
@@ -1,0 +1,5 @@
+package org.serenityos.jakt.comptime
+
+import com.intellij.openapi.util.TextRange
+
+class InterpreterException(message: String, val range: TextRange) : Exception(message)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
@@ -60,7 +60,6 @@ class ShowComptimeValueAction : AnAction() {
 
     private val AnActionEvent.element: PsiElement?
         get() {
-            // TODO: CommonDataKeys.PSI_ELEMENT?
             val file = dataContext.getData(CommonDataKeys.PSI_FILE) ?: return null
             val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return null
             return file.findElementAt(editor.caretModel.offset)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
@@ -1,0 +1,151 @@
+package org.serenityos.jakt.comptime
+
+import com.intellij.codeInsight.documentation.DocumentationComponent
+import com.intellij.codeInsight.documentation.DocumentationHtmlUtil
+import com.intellij.codeInsight.hint.HintManagerImpl
+import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.impl.EditorCssFontResolver
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.ui.LightweightHint
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.ui.HTMLEditorKitBuilder
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.ancestors
+import org.serenityos.jakt.psi.api.JaktCallExpression
+import org.serenityos.jakt.psi.api.JaktVariableDeclarationStatement
+import java.awt.Font
+import java.awt.Point
+import javax.swing.JEditorPane
+import javax.swing.text.StyledDocument
+
+class ShowComptimeValueAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.getComptimeTargetElement() != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val element = e.getComptimeTargetElement() ?: return
+        val hint = LightweightHint(ComptimePopup(element))
+        val editor = e.getData(CommonDataKeys.EDITOR)!!
+
+        HintManagerImpl.getInstanceImpl().showEditorHint(
+            hint,
+            editor,
+            HintManagerImpl.getHintPosition(hint, editor, editor.caretModel.logicalPosition, 0),
+            0,
+            0,
+            false,
+        )
+    }
+
+    private fun AnActionEvent.getComptimeTargetElement(): JaktPsiElement? {
+        val baseElement = element ?: return null
+
+        return baseElement.ancestors(withSelf = true).firstOrNull {
+            when (it) {
+                is JaktCallExpression,
+                is JaktVariableDeclarationStatement -> true
+                else -> false
+            }
+        } as? JaktPsiElement
+    }
+
+    private val AnActionEvent.element: PsiElement?
+        get() {
+            // TODO: CommonDataKeys.PSI_ELEMENT?
+            val file = dataContext.getData(CommonDataKeys.PSI_FILE) ?: return null
+            val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return null
+            return file.findElementAt(editor.caretModel.offset)
+        }
+
+    private operator fun Point.plus(other: Point) = Point(x + other.x, y + other.y)
+
+    @Suppress("UnstableApiUsage")
+    private class ComptimePopup(element: JaktPsiElement) : JEditorPane() {
+        init {
+            val editorKit = HTMLEditorKitBuilder()
+                .withFontResolver(EditorCssFontResolver.getGlobalInstance())
+                .build()
+
+            DocumentationHtmlUtil.addDocumentationPaneDefaultCssRules(editorKit)
+
+            // Overwrite a rule added by the above call: "html { padding-bottom: 8pm }"
+            editorKit.styleSheet.addRule("html { padding-bottom: 0px; }")
+
+            this.editorKit = editorKit
+            border = JBUI.Borders.empty()
+
+            // DocumentationEditorPane::applyFontProps
+            if (document is StyledDocument) {
+                val fontName = if (Registry.`is`("documentation.component.editor.font")) {
+                    EditorColorsManager.getInstance().globalScheme.editorFontName
+                } else font.fontName
+
+                font = UIUtil.getFontWithFallback(
+                    fontName,
+                    Font.PLAIN,
+                    JBUIScale.scale(DocumentationComponent.getQuickDocFontSize().size),
+                )
+            }
+
+            buildText(element)
+        }
+
+        private fun buildText(element: JaktPsiElement) {
+            val result = try {
+                Result.success(element.performComptimeEvaluation())
+            } catch (e: Throwable) {
+                Result.failure(e)
+            }
+
+            val builder = StringBuilder()
+
+            builder.append("<pre>")
+            // TODO: Render the text
+            builder.append(StringUtil.escapeXmlEntities(element.text))
+            builder.append("</pre>")
+            if (result.isSuccess) {
+                val output = result.getOrThrow()
+
+                builder.append(DocumentationMarkup.SECTIONS_START)
+                builder.append(DocumentationMarkup.SECTION_HEADER_START)
+                builder.append("Output")
+                builder.append(DocumentationMarkup.SECTION_SEPARATOR)
+                if (output.value == null) {
+                    builder.append("Unable to evaluate element")
+                } else {
+                    builder.append(StringUtil.escapeXmlEntities(output.value.toString()))
+                }
+                builder.append(DocumentationMarkup.SECTION_END)
+
+                if (output.stdout.isNotEmpty()) {
+                    builder.append(DocumentationMarkup.SECTION_HEADER_START)
+                    builder.append("stdout")
+                    builder.append(DocumentationMarkup.SECTION_SEPARATOR)
+                    builder.append(StringUtil.escapeXmlEntities(output.stdout).replace("\n", "<br />"))
+                    builder.append(DocumentationMarkup.SECTION_END)
+                }
+
+                if (output.stderr.isNotEmpty()) {
+                    builder.append(DocumentationMarkup.SECTION_HEADER_START)
+                    builder.append("stderr")
+                    builder.append(DocumentationMarkup.SECTION_SEPARATOR)
+                    builder.append(StringUtil.escapeXmlEntities(output.stderr).replace("\n", "<br />"))
+                    builder.append(DocumentationMarkup.SECTION_END)
+                }
+            } else {
+                builder.append(StringUtil.escapeXmlEntities("Internal error: ${result.exceptionOrNull()!!.message}"))
+            }
+
+            text = builder.toString()
+        }
+    }
+}

--- a/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/ShowComptimeValueAction.kt
@@ -18,9 +18,6 @@ import com.intellij.util.ui.HTMLEditorKitBuilder
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import org.serenityos.jakt.psi.JaktPsiElement
-import org.serenityos.jakt.psi.ancestors
-import org.serenityos.jakt.psi.api.JaktCallExpression
-import org.serenityos.jakt.psi.api.JaktVariableDeclarationStatement
 import java.awt.Font
 import java.awt.Point
 import javax.swing.JEditorPane
@@ -28,11 +25,11 @@ import javax.swing.text.StyledDocument
 
 class ShowComptimeValueAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = e.getComptimeTargetElement() != null
+        e.presentation.isEnabledAndVisible = e.element?.getComptimeTargetElement() != null
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-        val element = e.getComptimeTargetElement() ?: return
+        val element = e.element?.getComptimeTargetElement() ?: return
         val hint = LightweightHint(ComptimePopup(element))
         val editor = e.getData(CommonDataKeys.EDITOR)!!
 
@@ -44,18 +41,6 @@ class ShowComptimeValueAction : AnAction() {
             0,
             false,
         )
-    }
-
-    private fun AnActionEvent.getComptimeTargetElement(): JaktPsiElement? {
-        val baseElement = element ?: return null
-
-        return baseElement.ancestors(withSelf = true).firstOrNull {
-            when (it) {
-                is JaktCallExpression,
-                is JaktVariableDeclarationStatement -> true
-                else -> false
-            }
-        } as? JaktPsiElement
     }
 
     private val AnActionEvent.element: PsiElement?

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
@@ -20,32 +20,36 @@ sealed class Value {
     }
 }
 
+interface PrimitiveValue {
+    val value: Any
+}
+
 object VoidValue : Value() {
     override fun typeName() = "void"
     override fun toString() = "void"
 }
 
-data class BoolValue(val value: Boolean) : Value() {
+data class BoolValue(override val value: Boolean) : Value(), PrimitiveValue {
     override fun typeName() = "bool"
     override fun toString() = value.toString()
 }
 
-data class IntegerValue(val value: Long) : Value() {
+data class IntegerValue(override val value: Long) : Value(), PrimitiveValue {
     override fun typeName() = "i64"
     override fun toString() = value.toString()
 }
 
-data class FloatValue(val value: Double) : Value() {
+data class FloatValue(override val value: Double) : Value(), PrimitiveValue {
     override fun typeName() = "f64"
     override fun toString() = value.toString()
 }
 
-data class CharValue(val value: Char) : Value() {
+data class CharValue(override val value: Char) : Value(), PrimitiveValue {
     override fun typeName() = "c_char"
     override fun toString() = "'$value'"
 }
 
-data class ByteCharValue(val value: Byte) : Value() {
+data class ByteCharValue(override val value: Byte) : Value(), PrimitiveValue {
     override fun typeName() = "u8"
     override fun toString() = "b'$value'"
 }

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
@@ -1,7 +1,6 @@
 package org.serenityos.jakt.comptime
 
 import org.serenityos.jakt.psi.JaktPsiElement
-import org.serenityos.jakt.psi.api.JaktExpression
 
 // As with everything else in the plugin, we are very lenient when it comes to types.
 // All integers are treated as i64, just to make my life easier. Similarly, all float
@@ -9,6 +8,8 @@ import org.serenityos.jakt.psi.api.JaktExpression
 // compile, we'll get an IDE error for it anyways
 sealed class Value {
     private val fields = mutableMapOf<String, Value>()
+
+    abstract fun typeName(): String
 
     open operator fun contains(name: String) = name in fields
 
@@ -20,30 +21,37 @@ sealed class Value {
 }
 
 object VoidValue : Value() {
+    override fun typeName() = "void"
     override fun toString() = "void"
 }
 
 data class BoolValue(val value: Boolean) : Value() {
+    override fun typeName() = "bool"
     override fun toString() = value.toString()
 }
 
 data class IntegerValue(val value: Long) : Value() {
+    override fun typeName() = "i64"
     override fun toString() = value.toString()
 }
 
 data class FloatValue(val value: Double) : Value() {
+    override fun typeName() = "f64"
     override fun toString() = value.toString()
 }
 
 data class CharValue(val value: Char) : Value() {
+    override fun typeName() = "c_char"
     override fun toString() = "'$value'"
 }
 
 data class ByteCharValue(val value: Byte) : Value() {
+    override fun typeName() = "u8"
     override fun toString() = "b'$value'"
 }
 
 data class TupleValue(val values: List<Value>) : Value() {
+    override fun typeName() = "Tuple"
     override fun toString() = values.joinToString(prefix = "(", postfix = ")")
 }
 
@@ -55,9 +63,11 @@ abstract class FunctionValue(private val minParamCount: Int, private val maxPara
         require(minParamCount <= maxParamCount)
     }
 
+    override fun typeName() = "function"
+
     constructor(parameters: List<Parameter>) : this(parameters.count { it.default == null }, parameters.size)
 
-    abstract fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value
+    abstract fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Interpreter.ExecutionResult
 
     data class Parameter(val name: String, val default: Value? = null)
 }
@@ -66,7 +76,7 @@ class UserFunctionValue(
     private val parameters: List<Parameter>,
     val body: JaktPsiElement /* JaktBlock | JaktExpression */, // TODO: Storing PSI is bad, right?
 ) : FunctionValue(parameters) {
-    override fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value {
+    override fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Interpreter.ExecutionResult {
         val newScope = Interpreter.FunctionScope(interpreter.scope, thisValue)
 
         for ((index, param) in parameters.withIndex()) {
@@ -80,15 +90,12 @@ class UserFunctionValue(
 
         interpreter.pushScope(newScope)
 
-        return try {
-            interpreter.evaluate(body).let {
-                if (body is JaktExpression) it!! else VoidValue
-            }
-        } catch (e: Interpreter.ReturnException) {
-            e.value ?: VoidValue
-        } catch (e: Interpreter.FlowException) {
-            error("Unexpected FlowException in UserFunction: ${e::class.simpleName}")
-        } finally {
+        return when (val result = interpreter.evaluate(body)) {
+            is Interpreter.ExecutionResult.Normal -> Interpreter.ExecutionResult.Normal(VoidValue)
+            is Interpreter.ExecutionResult.Return -> Interpreter.ExecutionResult.Normal(result.value)
+            is Interpreter.ExecutionResult.Throw -> result
+            else -> interpreter.error("Unexpected control flow", body)
+        }.also {
             interpreter.popScope()
         }
     }

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
@@ -1,6 +1,7 @@
 package org.serenityos.jakt.comptime
 
 import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.api.JaktExpression
 
 // As with everything else in the plugin, we are very lenient when it comes to types.
 // All integers are treated as i64, just to make my life easier. Similarly, all float
@@ -95,7 +96,9 @@ class UserFunctionValue(
         interpreter.pushScope(newScope)
 
         return when (val result = interpreter.evaluate(body)) {
-            is Interpreter.ExecutionResult.Normal -> Interpreter.ExecutionResult.Normal(VoidValue)
+            is Interpreter.ExecutionResult.Normal -> if (body is JaktExpression) {
+                Interpreter.ExecutionResult.Normal(result.value)
+            } else Interpreter.ExecutionResult.Normal(VoidValue)
             is Interpreter.ExecutionResult.Return -> Interpreter.ExecutionResult.Normal(result.value)
             is Interpreter.ExecutionResult.Throw -> result
             else -> interpreter.error("Unexpected control flow", body)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
@@ -1,0 +1,106 @@
+package org.serenityos.jakt.comptime
+
+import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.api.JaktExpression
+
+// As with everything else in the plugin, we are very lenient when it comes to types.
+// All integers are treated as i64, just to make my life easier. Similarly, all float
+// types are treated as f64. If we produce a value for something that doesn't actually
+// compile, we'll get an IDE error for it anyways
+sealed interface Value
+
+object VoidValue : Value {
+    override fun toString() = "void"
+}
+
+data class BoolValue(val value: Boolean) : Value {
+    override fun toString() = value.toString()
+}
+
+data class IntegerValue(val value: Long) : Value {
+    override fun toString() = value.toString()
+}
+
+data class FloatValue(val value: Double) : Value {
+    override fun toString() = value.toString()
+}
+
+data class CharValue(val value: Char) : Value {
+    override fun toString() = "'$value'"
+}
+
+data class ByteCharValue(val value: Byte) : Value {
+    override fun toString() = "b'$value'"
+}
+
+data class StringValue(val value: String) : Value {
+    override fun toString() = "\"$value\""
+}
+
+data class TupleValue(val values: List<Value>) : Value {
+    override fun toString() = values.joinToString(prefix = "(", postfix = ")")
+}
+
+data class ArrayValue(val values: List<Value>) : Value {
+    override fun toString() = values.joinToString(prefix = "[", postfix = "]")
+}
+
+data class SetValue(val values: Set<Value>) : Value {
+    override fun toString() = values.joinToString(prefix = "{", postfix = "}")
+}
+
+data class DictionaryValue(val elements: Map<Value, Value>) : Value {
+    override fun toString() = elements.entries.joinToString(prefix = "{", postfix = "}") {
+        "${it.key}: ${it.value}"
+    }
+}
+
+open class StructValue : Value {
+    protected val fieldsBacker = mutableMapOf<String, Value>()
+
+    val fields: Map<String, Value>
+        get() = fieldsBacker
+
+    open operator fun get(name: String) = fields[name]
+}
+
+abstract class FunctionValue(val parameters: List<Parameter>) : Value {
+    val validParamCount: IntRange
+        get() = parameters.count { it.default != null }..parameters.size
+
+    abstract fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value
+
+    data class Parameter(val name: String, val default: Value? = null)
+}
+
+class UserFunctionValue(
+    parameters: List<Parameter>,
+    val body: JaktPsiElement /* JaktBlock | JaktExpression */, // TODO: Storing PSI is bad, right?
+) : FunctionValue(parameters) {
+    override fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value {
+        val newScope = Interpreter.FunctionScope(interpreter.scope, thisValue)
+
+        for ((index, param) in parameters.withIndex()) {
+            if (index <= arguments.lastIndex) {
+                newScope.initialize(param.name, arguments[index])
+            } else {
+                check(param.default != null)
+                newScope.initialize(param.name, param.default)
+            }
+        }
+
+        interpreter.pushScope(newScope)
+
+        return try {
+            interpreter.evaluate(body).let {
+                if (body is JaktExpression) it!! else VoidValue
+            }
+        } catch (e: Interpreter.ReturnException) {
+            e.value ?: VoidValue
+        } catch (e: Interpreter.FlowException) {
+            error("Unexpected FlowException in UserFunction: ${e::class.simpleName}")
+        } finally {
+            interpreter.popScope()
+        }
+    }
+}

--- a/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/Value.kt
@@ -50,7 +50,7 @@ data class ByteCharValue(val value: Byte) : Value() {
     override fun toString() = "b'$value'"
 }
 
-data class TupleValue(val values: List<Value>) : Value() {
+data class TupleValue(val values: MutableList<Value>) : Value() {
     override fun typeName() = "Tuple"
     override fun toString() = values.joinToString(prefix = "(", postfix = ")")
 }
@@ -81,10 +81,10 @@ class UserFunctionValue(
 
         for ((index, param) in parameters.withIndex()) {
             if (index <= arguments.lastIndex) {
-                newScope.initialize(param.name, arguments[index])
+                newScope[param.name] = arguments[index]
             } else {
                 check(param.default != null)
-                newScope.initialize(param.name, param.default)
+                newScope[param.name] = param.default
             }
         }
 

--- a/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
@@ -192,7 +192,7 @@ object StringStruct : Value() {
         val (char, count) = arguments
         require(char is CharValue && count is IntegerValue)
         StringValue(buildString {
-            repeat(count.value.toInt()) { append(char) }
+            repeat(count.value.toInt()) { append(char.value) }
         })
     }
 
@@ -274,17 +274,17 @@ data class StringValue(override val value: String) : Value(), PrimitiveValue {
             require(thisValue is StringValue)
             val (start, end) = arguments
             require(start is IntegerValue && end is IntegerValue)
-            StringValue(thisValue.value.substring(start.value.toInt(), end.value.toInt()))
+            StringValue(thisValue.value.substring(start.value.toInt(), (start.value + end.value).toInt()))
         }
 
         private val toUInt = BuiltinFunction(0) { thisValue, _ ->
             require(thisValue is StringValue)
-            IntegerValue(thisValue.value.toLong())
+            OptionalValue(thisValue.value.toLongOrNull()?.let(::IntegerValue))
         }
 
         private val toInt = BuiltinFunction(0) { thisValue, _ ->
             require(thisValue is StringValue)
-            IntegerValue(thisValue.value.toLong())
+            OptionalValue(thisValue.value.toLongOrNull()?.let(::IntegerValue))
         }
 
         private val isWhitespace = BuiltinFunction(0) { thisValue, _ ->

--- a/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
@@ -1,47 +1,352 @@
 package org.serenityos.jakt.comptime
 
+import org.serenityos.jakt.project.JaktProjectListener
+import java.io.File
+
 class BuiltinFunction(
-    parameters: List<Parameter>,
+    parameterCount: Int,
     private val func: (Value?, List<Value>) -> Value,
-) : FunctionValue(parameters.toList()) {
-    constructor(vararg parameters: Parameter, func: (Value?, List<Value>) -> Value) :
-        this(parameters.toList(), func)
-
-    constructor(vararg parameterNames: String, func: (Value?, List<Value>) -> Value) :
-        this(parameterNames.map { Parameter(it) }, func)
-
-    constructor(func: (Value?, List<Value>) -> Value) : this(emptyList(), func)
-
+) : FunctionValue(parameterCount, parameterCount) {
     override fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value {
         return func(thisValue, arguments)
     }
 }
 
-object StringBuilderStruct : StructValue() {
-    private val create = BuiltinFunction { thisValue, arguments ->
+data class OptionalValue(val value: Value?) : Value() {
+    init {
+        this["has_value"] = hasValue
+        this["value"] = getValue
+        this["value_or"] = getValueOr
+    }
+
+    override fun toString() = "Optional(${value?.toString() ?: "<empty>"})"
+
+    companion object {
+        private val hasValue = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is OptionalValue)
+            BoolValue(thisValue.value != null)
+        }
+
+        private val getValue = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is OptionalValue)
+            thisValue.value!!
+        }
+
+        private val getValueOr = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is OptionalValue)
+            thisValue.value ?: arguments[0]
+        }
+    }
+}
+
+data class ArrayIterator(
+    val array: ArrayValue,
+    private var nextIndex: Int = 0,
+    private val endInclusiveIndex: Int = array.values.lastIndex,
+) : Value() {
+    init {
+        this["next"] = next
+    }
+
+    companion object {
+        private val next = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayIterator)
+            if (thisValue.nextIndex > thisValue.endInclusiveIndex) {
+                OptionalValue(null)
+            } else OptionalValue(thisValue.array.values[thisValue.nextIndex]).also {
+                thisValue.nextIndex += 1
+            }
+        }
+    }
+}
+
+data class ArrayValue(val values: MutableList<Value>) : Value() {
+    override fun toString() = values.joinToString(prefix = "[", postfix = "]")
+
+    init {
+        this["is_empty"] = isEmpty
+        this["size"] = size
+        this["contains"] = contains
+        this["iterator"] = iterator
+        this["push"] = push
+        this["pop"] = pop
+        this["first"] = first
+        this["last"] = last
+    }
+
+    companion object {
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            BoolValue(thisValue.values.isEmpty())
+        }
+
+        private val size = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            IntegerValue(thisValue.values.size.toLong())
+        }
+
+        private val contains = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is ArrayValue)
+            BoolValue(arguments[0] in thisValue.values)
+        }
+
+        private val iterator = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            ArrayIterator(thisValue)
+        }
+
+        private val push = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is ArrayValue)
+            thisValue.values.add(arguments[0])
+            VoidValue
+        }
+
+        private val pop = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            if (thisValue.values.isEmpty()) {
+                OptionalValue(null)
+            } else OptionalValue(thisValue.values.removeLast())
+        }
+
+        private val first = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            OptionalValue(thisValue.values.firstOrNull())
+        }
+
+        private val last = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArrayValue)
+            OptionalValue(thisValue.values.lastOrNull())
+        }
+    }
+}
+
+data class ArraySlice(val array: ArrayValue, val range: IntRange) : Value() {
+    init {
+        this["is_empty"] = isEmpty
+        this["contains"] = contains
+        this["size"] = size
+        this["iterator"] = iterator
+        this["to_array"] = toArray
+        this["first"] = first
+        this["last"] = last
+    }
+
+    companion object {
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+            BoolValue(thisValue.range.isEmpty() || thisValue.array.values.slice(thisValue.range).isEmpty())
+        }
+
+        private val contains = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is ArraySlice)
+            BoolValue(arguments[0] in thisValue.array.values.slice(thisValue.range))
+        }
+
+        private val size = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+
+            // Note: this is what Jakt does, not totally sure why
+            if (thisValue.range.last > thisValue.array.values.size) {
+                IntegerValue(0)
+            } else IntegerValue((thisValue.range.last - thisValue.range.first).toLong())
+        }
+
+        private val iterator = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+            ArrayIterator(thisValue.array, thisValue.range.first, thisValue.range.last)
+        }
+
+        private val toArray = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+            ArrayValue(thisValue.array.values.slice(thisValue.range).toMutableList())
+        }
+
+        private val first = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+            thisValue.array.values[thisValue.range.first]
+        }
+
+        private val last = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is ArraySlice)
+            thisValue.array.values[thisValue.range.last]
+        }
+    }
+}
+
+object StringStruct : Value() {
+    private val repeated = BuiltinFunction(2) { thisValue, arguments ->
+        require(thisValue == null)
+        val (char, count) = arguments
+        require(char is CharValue && count is IntegerValue)
+        StringValue(buildString {
+            repeat(count.value.toInt()) { append(char) }
+        })
+    }
+
+    private val number = BuiltinFunction(1) { thisValue, arguments ->
+        require(thisValue == null)
+        val arg = arguments[0]
+        require(arg is IntegerValue)
+        StringValue(arg.value.toString())
+    }
+
+    init {
+        this["number"] = number
+        this["repeated"] = repeated
+    }
+}
+
+data class StringValue(val value: String) : Value() {
+    init {
+        this["is_empty"] = isEmpty
+        this["length"] = length
+        this["hash"] = hash
+        this["substring"] = substring
+        this["to_uint"] = toUInt
+        this["to_int"] = toInt
+        this["is_whitespace"] = isWhitespace
+        this["contains"] = contains
+        this["replace"] = replace
+        this["byte_at"] = byteAt
+        this["split"] = split
+        this["starts_with"] = startsWith
+        this["ends_with"] = endsWith
+    }
+
+    override fun toString() = "\"$value\""
+
+    companion object {
+        private val whiteSpace = setOf(' ', '\t', '\n', 0xb.toChar() /* \v */, 0xc.toChar() /* \f */, '\r')
+
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            BoolValue(thisValue.value.isEmpty())
+        }
+
+        private val length = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            IntegerValue(thisValue.value.length.toLong())
+        }
+
+        private val hash = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            val string = thisValue.value
+
+            // See runtime/Jakt/StringHash.h
+            if (string.isEmpty())
+                return@BuiltinFunction IntegerValue(0L)
+
+            var hash = string.length
+
+            for (ch in string) {
+                hash += ch.code
+                hash += hash shl 10
+                hash = hash or (hash shr 6)
+            }
+
+            hash += hash shl 3
+            hash = hash or (hash shr 11)
+            hash += hash shl 15
+
+            IntegerValue(hash.toLong())
+        }
+
+        private val substring = BuiltinFunction(2) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val (start, end) = arguments
+            require(start is IntegerValue && end is IntegerValue)
+            StringValue(thisValue.value.substring(start.value.toInt(), end.value.toInt()))
+        }
+
+        private val toUInt = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            IntegerValue(thisValue.value.toLong())
+        }
+
+        private val toInt = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            IntegerValue(thisValue.value.toLong())
+        }
+
+        private val isWhitespace = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringValue)
+            BoolValue(thisValue.value.all { it in whiteSpace })
+        }
+
+        private val contains = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val arg = arguments[0]
+            require(arg is StringValue)
+            BoolValue(arg.value in thisValue.value)
+        }
+
+        private val replace = BuiltinFunction(2) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val (replace, with) = arguments
+            require(replace is StringValue && with is StringValue)
+            StringValue(thisValue.value.replace(replace.value, with.value))
+        }
+
+        private val byteAt = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val arg = arguments[0]
+            require(arg is IntegerValue)
+            IntegerValue(thisValue.value.toByteArray()[arg.value.toInt()].toLong())
+        }
+
+        private val split = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val arg = arguments[0]
+            require(arg is CharValue)
+            ArrayValue(thisValue.value.split(arg.value).map(::StringValue).toMutableList())
+        }
+
+        private val startsWith = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val arg = arguments[0]
+            require(arg is StringValue)
+            BoolValue(thisValue.value.startsWith(arg.value))
+        }
+
+        private val endsWith = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is StringValue)
+            val arg = arguments[0]
+            require(arg is StringValue)
+            BoolValue(thisValue.value.endsWith(arg.value))
+        }
+    }
+}
+
+object StringBuilderStruct : Value() {
+    private val create = BuiltinFunction(0) { thisValue, arguments ->
         require(thisValue == null)
         require(arguments.isEmpty())
         StringBuilderInstance()
     }
 
     init {
-        fieldsBacker["create"] = create
+        this["create"] = create
     }
 }
 
-class StringBuilderInstance : StructValue() {
+class StringBuilderInstance : Value() {
     val builder = StringBuilder()
 
     init {
-        fieldsBacker["append"] = append
-        fieldsBacker["append_string"] = appendString
-        fieldsBacker["to_string"] = toString
+        this["append"] = append
+        this["append_string"] = appendString
+        this["append_code_point"] = appendCodePoint
+        this["to_string"] = toString
+        this["is_empty"] = isEmpty
+        this["length"] = length
+        this["clear"] = clear
     }
 
+    override fun toString() = "StringBuilder(content = \"$builder\")"
+
     companion object {
-        private val append = BuiltinFunction("b") { thisValue, arguments ->
+        private val append = BuiltinFunction(1) { thisValue, arguments ->
             require(thisValue is StringBuilderInstance)
-            require(arguments.size == 1)
             val arg = arguments[0]
             require(arg is ByteCharValue)
 
@@ -49,9 +354,8 @@ class StringBuilderInstance : StructValue() {
             VoidValue
         }
 
-        private val appendString = BuiltinFunction("s") { thisValue, arguments ->
+        private val appendString = BuiltinFunction(1) { thisValue, arguments ->
             require(thisValue is StringBuilderInstance)
-            require(arguments.size == 1)
             val arg = arguments[0]
             require(arg is StringValue)
 
@@ -59,10 +363,302 @@ class StringBuilderInstance : StructValue() {
             VoidValue
         }
 
-        private val toString = BuiltinFunction { thisValue, arguments ->
+        private val appendCodePoint = BuiltinFunction(1) { thisValue, arguments ->
             require(thisValue is StringBuilderInstance)
-            require(arguments.isEmpty())
+            val arg = arguments[0]
+            require(arg is IntegerValue)
+
+            thisValue.builder.appendCodePoint(arg.value.toInt())
+            VoidValue
+        }
+
+        private val toString = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringBuilderInstance)
             StringValue(thisValue.builder.toString())
+        }
+
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringBuilderInstance)
+            BoolValue(thisValue.builder.isEmpty())
+        }
+
+        private val length = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringBuilderInstance)
+            IntegerValue(thisValue.builder.length.toLong())
+        }
+
+        private val clear = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is StringBuilderInstance)
+            thisValue.builder.clear()
+            VoidValue
         }
     }
 }
+
+// TODO: no clue if this is works the way it does in Jakt
+data class DictionaryIterator(val dictionary: DictionaryValue) : Value() {
+    private val remainingKeys = dictionary.elements.keys
+
+    init {
+        this["next"] = next
+    }
+
+    companion object {
+        private val next = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryIterator)
+            val nextKey = thisValue.remainingKeys.random()
+            thisValue.remainingKeys.remove(nextKey)
+            TupleValue(listOf(nextKey, thisValue.dictionary.elements[nextKey]!!))
+        }
+    }
+}
+
+data class DictionaryValue(val elements: MutableMap<Value, Value>) : Value() {
+    init {
+        this["is_empty"] = isEmpty
+        this["get"] = get
+        this["contains"] = contains
+        this["set"] = set
+        this["remove"] = remove
+        this["clear"] = clear
+        this["size"] = size
+        this["keys"] = keys
+        this["iterator"] = iterator
+    }
+
+    override fun toString() = elements.entries.joinToString(prefix = "{", postfix = "}") {
+        "${it.key}: ${it.value}"
+    }
+
+    companion object {
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryValue)
+            BoolValue(thisValue.elements.isEmpty())
+        }
+
+        private val get = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is DictionaryValue)
+            require(arguments.size == 1)
+            OptionalValue(thisValue.elements[arguments[0]])
+        }
+
+        private val contains = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is DictionaryValue)
+            BoolValue(arguments[0] in thisValue.elements)
+        }
+
+        private val set = BuiltinFunction(2) { thisValue, arguments ->
+            require(thisValue is DictionaryValue)
+            thisValue.elements[arguments[0]] = arguments[1]
+            VoidValue
+        }
+
+        private val remove = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is DictionaryValue)
+            BoolValue(thisValue.elements.remove(arguments[0]) != null)
+        }
+
+        private val clear = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryValue)
+            thisValue.elements.clear()
+            VoidValue
+        }
+
+        private val size = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryValue)
+            IntegerValue(thisValue.elements.size.toLong())
+        }
+
+        // TODO: What is the ordering guarantee for this in Jakt?
+        private val keys = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryValue)
+            ArrayValue(thisValue.elements.keys.toMutableList())
+        }
+
+        private val iterator = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is DictionaryValue)
+            DictionaryIterator(thisValue)
+        }
+    }
+}
+
+data class SetIterator(val values: MutableSet<Value>) : Value() {
+    init {
+        this["next"] = next
+    }
+
+    companion object {
+        private val next = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is SetIterator)
+            val nextValue = thisValue.values.random()
+            thisValue.values.remove(nextValue)
+            nextValue
+        }
+    }
+}
+
+data class SetValue(val values: MutableSet<Value>) : Value() {
+    init {
+        this["is_empty"] = isEmpty
+        this["contains"] = contains
+        this["add"] = add
+        this["remove"] = remove
+        this["clear"] = clear
+        this["size"] = size
+        this["iterator"] = iterator
+    }
+
+    override fun toString() = values.joinToString(prefix = "{", postfix = "}")
+
+    companion object {
+        private val isEmpty = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is SetValue)
+            BoolValue(thisValue.values.isEmpty())
+        }
+
+        private val contains = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is SetValue)
+            BoolValue(arguments[0] in thisValue.values)
+        }
+
+        private val add = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is SetValue)
+            thisValue.values.add(arguments[0])
+            VoidValue
+        }
+
+        private val remove = BuiltinFunction(1) { thisValue, arguments ->
+            require(thisValue is SetValue)
+            BoolValue(thisValue.values.remove(arguments[0]))
+        }
+
+        private val clear = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is SetValue)
+            thisValue.values.clear()
+            VoidValue
+        }
+
+        private val size = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is SetValue)
+            IntegerValue(thisValue.values.size.toLong())
+        }
+
+        private val iterator = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is SetValue)
+            SetIterator(thisValue.values.toMutableSet())
+        }
+    }
+}
+
+data class RangeValue(val start: Long, val end: Long, val isInclusive: Boolean) : Value() {
+    private var current = start
+    private val forwards = start <= end
+
+    val range: IntRange
+        get() = if (isInclusive) start.toInt()..end.toInt() else start.toInt() until end.toInt()
+
+    init {
+        this["next"] = next
+        this["inclusive"] = inclusive
+        this["exclusive"] = exclusive
+    }
+
+    private fun getAndAdvance(): Long {
+        return current.also {
+            if (forwards) current++ else current--
+        }
+    }
+
+    private fun isDone(): Boolean {
+        return when {
+            forwards && isInclusive -> current > end
+            forwards -> current >= end
+            isInclusive -> current < start
+            else -> current <= start
+        }
+    }
+
+    companion object {
+        private val next = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is RangeValue)
+            if (thisValue.isDone()) {
+                OptionalValue(null)
+            } else OptionalValue(IntegerValue(thisValue.getAndAdvance()))
+        }
+
+        private val inclusive = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is RangeValue)
+            thisValue.copy(isInclusive = true)
+        }
+
+        private val exclusive = BuiltinFunction(0) { thisValue, _ ->
+            require(thisValue is RangeValue)
+            thisValue.copy(isInclusive = false)
+        }
+    }
+}
+
+object ErrorStruct : Value() {
+    private val fromErrno = BuiltinFunction(1) { thisValue, arguments ->
+        require(thisValue == null)
+        val arg = arguments[0]
+        require(arg is IntegerValue)
+        ErrorInstance(arg.value)
+    }
+
+    init {
+        this["from_errno"] = fromErrno
+    }
+}
+
+class ErrorInstance(private val codeValue: Long) : Value() {
+    override fun toString() = "Error(code = $codeValue)"
+}
+
+object FileStruct : Value() {
+    private val exists = BuiltinFunction(1) { thisValue, arguments ->
+        require(thisValue == null)
+        val arg = arguments[0]
+        require(arg is StringValue)
+        BoolValue(File(arg.value).exists())
+    }
+
+    private val openForReading = BuiltinFunction(1) { thisValue, arguments ->
+        require(thisValue == null)
+        val arg = arguments[0]
+        require(arg is StringValue)
+        FileInstance(File(arg.value))
+    }
+
+    init {
+        this["exists"] = exists
+        this["open_for_reading"] = openForReading
+    }
+}
+
+class FileInstance(val file: File) : Value() {
+    init {
+        this["read_all"] = readAll
+    }
+
+    companion object {
+        private val readAll = BuiltinFunction(0) { thisValue, arguments ->
+            require(thisValue is FileInstance)
+            require(arguments.isEmpty())
+            StringValue(thisValue.file.readText())
+        }
+    }
+}
+
+// Free functions
+
+val jaktGetTargetTripleStringFunction = BuiltinFunction(0) { _, _ ->
+    JaktProjectListener.targetTriple.get() ?: StringValue("unknown-unknown-unknown-unknown")
+}
+
+val abortFunction = BuiltinFunction(0) { _, _ -> error("aborted") }
+
+// TODO: saturated/truncated functions when we have generic information
+
+// TODO: Format functions, not trivial since Kotlin does not support the
+//       Serenity/Python-style format arguments

--- a/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
@@ -436,7 +436,7 @@ data class DictionaryIterator(val dictionary: DictionaryValue) : Value() {
             require(thisValue is DictionaryIterator)
             val nextKey = thisValue.remainingKeys.random()
             thisValue.remainingKeys.remove(nextKey)
-            TupleValue(listOf(nextKey, thisValue.dictionary.elements[nextKey]!!))
+            TupleValue(mutableListOf(nextKey, thisValue.dictionary.elements[nextKey]!!))
         }
     }
 }

--- a/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/builtins.kt
@@ -1,0 +1,68 @@
+package org.serenityos.jakt.comptime
+
+class BuiltinFunction(
+    parameters: List<Parameter>,
+    private val func: (Value?, List<Value>) -> Value,
+) : FunctionValue(parameters.toList()) {
+    constructor(vararg parameters: Parameter, func: (Value?, List<Value>) -> Value) :
+        this(parameters.toList(), func)
+
+    constructor(vararg parameterNames: String, func: (Value?, List<Value>) -> Value) :
+        this(parameterNames.map { Parameter(it) }, func)
+
+    constructor(func: (Value?, List<Value>) -> Value) : this(emptyList(), func)
+
+    override fun call(interpreter: Interpreter, thisValue: Value?, arguments: List<Value>): Value {
+        return func(thisValue, arguments)
+    }
+}
+
+object StringBuilderStruct : StructValue() {
+    private val create = BuiltinFunction { thisValue, arguments ->
+        require(thisValue == null)
+        require(arguments.isEmpty())
+        StringBuilderInstance()
+    }
+
+    init {
+        fieldsBacker["create"] = create
+    }
+}
+
+class StringBuilderInstance : StructValue() {
+    val builder = StringBuilder()
+
+    init {
+        fieldsBacker["append"] = append
+        fieldsBacker["append_string"] = appendString
+        fieldsBacker["to_string"] = toString
+    }
+
+    companion object {
+        private val append = BuiltinFunction("b") { thisValue, arguments ->
+            require(thisValue is StringBuilderInstance)
+            require(arguments.size == 1)
+            val arg = arguments[0]
+            require(arg is ByteCharValue)
+
+            thisValue.builder.appendCodePoint(arg.value.toInt())
+            VoidValue
+        }
+
+        private val appendString = BuiltinFunction("s") { thisValue, arguments ->
+            require(thisValue is StringBuilderInstance)
+            require(arguments.size == 1)
+            val arg = arguments[0]
+            require(arg is StringValue)
+
+            thisValue.builder.append(arg.value)
+            VoidValue
+        }
+
+        private val toString = BuiltinFunction { thisValue, arguments ->
+            require(thisValue is StringBuilderInstance)
+            require(arguments.isEmpty())
+            StringValue(thisValue.builder.toString())
+        }
+    }
+}

--- a/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
@@ -1,9 +1,13 @@
 package org.serenityos.jakt.comptime
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.childrenOfType
 import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.ancestors
 import org.serenityos.jakt.psi.api.JaktBlock
+import org.serenityos.jakt.psi.api.JaktCallExpression
 import org.serenityos.jakt.psi.api.JaktIfStatement
+import org.serenityos.jakt.psi.api.JaktVariableDeclarationStatement
 import org.serenityos.jakt.psi.caching.comptimeCache
 import org.serenityos.jakt.psi.findChildOfType
 
@@ -11,6 +15,18 @@ fun JaktPsiElement.performComptimeEvaluation(): Interpreter.Result {
     return comptimeCache().resolveWithCaching(this) {
         Interpreter.evaluate(this)
     }
+}
+
+fun PsiElement.getComptimeTargetElement(): JaktPsiElement? {
+    val baseElement = this
+
+    return baseElement.ancestors(withSelf = true).firstOrNull {
+        when (it) {
+            is JaktCallExpression,
+            is JaktVariableDeclarationStatement -> true
+            else -> false
+        }
+    } as? JaktPsiElement
 }
 
 // Utility accessors

--- a/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
@@ -11,8 +11,11 @@ import org.serenityos.jakt.psi.findChildOfType
 val JaktPsiElement.comptimeValue: Value?
     get() = comptimeCache().resolveWithCaching(this) {
         try {
-            Interpreter.evaluate(this)
-        } catch (e: Throwable) {
+            when (val result = Interpreter.evaluate(this)) {
+                is Interpreter.ExecutionResult.Normal -> result.value
+                else -> null
+            }
+        } catch (e: InterpreterException) {
             null
         }.let(::Ref)
     }.get()
@@ -23,6 +26,3 @@ val JaktIfStatement.ifStatement: JaktIfStatement?
 
 val JaktIfStatement.elseBlock: JaktBlock?
     get() = childrenOfType<JaktBlock>().getOrNull(1)
-
-val JaktIfStatement.canBeExpr: Boolean
-    get() = elseKeyword != null && (ifStatement != null || elseBlock != null)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
@@ -1,13 +1,21 @@
 package org.serenityos.jakt.comptime
 
+import com.intellij.openapi.util.Ref
 import com.intellij.psi.util.childrenOfType
 import org.serenityos.jakt.psi.JaktPsiElement
-import org.serenityos.jakt.psi.ancestorsOfType
 import org.serenityos.jakt.psi.api.JaktBlock
-import org.serenityos.jakt.psi.api.JaktCallExpression
-import org.serenityos.jakt.psi.api.JaktFunction
 import org.serenityos.jakt.psi.api.JaktIfStatement
+import org.serenityos.jakt.psi.caching.comptimeCache
 import org.serenityos.jakt.psi.findChildOfType
+
+val JaktPsiElement.comptimeValue: Value?
+    get() = comptimeCache().resolveWithCaching(this) {
+        try {
+            Interpreter.evaluate(this)
+        } catch (e: Throwable) {
+            null
+        }.let(::Ref)
+    }.get()
 
 // Utility accessors
 val JaktIfStatement.ifStatement: JaktIfStatement?

--- a/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
@@ -1,6 +1,5 @@
 package org.serenityos.jakt.comptime
 
-import com.intellij.openapi.util.Ref
 import com.intellij.psi.util.childrenOfType
 import org.serenityos.jakt.psi.JaktPsiElement
 import org.serenityos.jakt.psi.api.JaktBlock
@@ -8,17 +7,11 @@ import org.serenityos.jakt.psi.api.JaktIfStatement
 import org.serenityos.jakt.psi.caching.comptimeCache
 import org.serenityos.jakt.psi.findChildOfType
 
-val JaktPsiElement.comptimeValue: Value?
-    get() = comptimeCache().resolveWithCaching(this) {
-        try {
-            when (val result = Interpreter.evaluate(this)) {
-                is Interpreter.ExecutionResult.Normal -> result.value
-                else -> null
-            }
-        } catch (e: InterpreterException) {
-            null
-        }.let(::Ref)
-    }.get()
+fun JaktPsiElement.performComptimeEvaluation(): Interpreter.Result {
+    return comptimeCache().resolveWithCaching(this) {
+        Interpreter.evaluate(this)
+    }
+}
 
 // Utility accessors
 val JaktIfStatement.ifStatement: JaktIfStatement?

--- a/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/extensions.kt
@@ -1,0 +1,20 @@
+package org.serenityos.jakt.comptime
+
+import com.intellij.psi.util.childrenOfType
+import org.serenityos.jakt.psi.JaktPsiElement
+import org.serenityos.jakt.psi.ancestorsOfType
+import org.serenityos.jakt.psi.api.JaktBlock
+import org.serenityos.jakt.psi.api.JaktCallExpression
+import org.serenityos.jakt.psi.api.JaktFunction
+import org.serenityos.jakt.psi.api.JaktIfStatement
+import org.serenityos.jakt.psi.findChildOfType
+
+// Utility accessors
+val JaktIfStatement.ifStatement: JaktIfStatement?
+    get() = findChildOfType()
+
+val JaktIfStatement.elseBlock: JaktBlock?
+    get() = childrenOfType<JaktBlock>().getOrNull(1)
+
+val JaktIfStatement.canBeExpr: Boolean
+    get() = elseKeyword != null && (ifStatement != null || elseBlock != null)

--- a/src/main/kotlin/org/serenityos/jakt/comptime/formatStrings.kt
+++ b/src/main/kotlin/org/serenityos/jakt/comptime/formatStrings.kt
@@ -1,0 +1,378 @@
+package org.serenityos.jakt.comptime
+
+import com.intellij.openapi.util.Ref
+import org.serenityos.jakt.utils.unreachable
+
+// Based on https://github.com/SerenityOS/serenity/blob/master/AK/Format.cpp
+
+data class FormatString(
+    private val literals: List<String>,
+    private val specifierStrings: List<String>,
+) {
+    init {
+        require(specifierStrings.size == literals.size - 1)
+    }
+
+    fun apply(arguments: List<Value>): String {
+        val context = Context(arguments)
+        val specifiers = specifierStrings.map { FormatSpecifierParser(it).parse(context) }
+
+        return buildString {
+            append(literals[0])
+
+            for (i in specifiers.indices) {
+                specifiers[i].apply(this, arguments)
+                append(literals[i + 1])
+            }
+        }
+    }
+}
+
+data class Specifier(
+    var index: Int = 0,
+    var alignment: Alignment = Alignment.Right,
+    var sign: Sign = Sign.OnlyIfNeeded,
+    var mode: Mode = Mode.Default,
+    var alternative: Boolean = false,
+    var fillChar: Char = ' ',
+    var zeroPad: Boolean = false,
+    var width: Int? = null,
+    var precision: Int? = null,
+) {
+    enum class Alignment {
+        Left,
+        Center,
+        Right,
+    }
+
+    enum class Sign {
+        OnlyIfNeeded,
+        Always,
+        Reserved,
+    }
+
+    enum class Mode(val str: kotlin.String) {
+        Default(""),
+        Binary("b"),
+        BinaryUppercase("B"),
+        Decimal("d"),
+        Octal("o"),
+        Hexadecimal("x"),
+        HexadecimalUppercase("X"),
+        Character("c"),
+        String("s"),
+        Pointer("p"),
+        Float("f"),
+        HexFloat("a"),
+        HexFloatUppercase("A"),
+        HexDump("hex-dump"),
+    }
+
+    // TODO: This needs a lot of work to be accurate
+    fun apply(builder: StringBuilder, arguments: List<Value>) {
+        val target = arguments.getOrNull(index) ?:
+            error("Format specifier refers to argument ${index + 1}, but only ${arguments.size} arguments were provided")
+
+        check(target is PrimitiveValue) { "Cannot format non-primitive type ${target.typeName()} at comptime" }
+
+        check(mode != Mode.Pointer && mode != Mode.HexDump && mode != Mode.Binary && mode != Mode.BinaryUppercase) {
+            "Unsupported format specifier '${mode.str}'"
+        }
+
+        check(alignment != Alignment.Center) {
+            "Unsupported alignment '^'"
+        }
+
+        check(fillChar == ' ') {
+            "Unsupported non-space fill character"
+        }
+
+        val javaFormatSpecifier = buildString {
+            append('%')
+
+            if (alignment == Alignment.Left)
+                append('-')
+
+            if (alternative)
+                append('#')
+
+            when (sign) {
+                Sign.Always -> append('+')
+                Sign.Reserved -> append(' ')
+                Sign.OnlyIfNeeded -> {}
+            }
+
+            if (zeroPad)
+                append('0')
+
+            if (width != null)
+                append(width)
+
+            if (precision != null) {
+                append('.')
+                append(precision)
+            }
+
+            if (mode == Mode.Default) {
+                mode = when (target) {
+                    is StringValue -> Mode.String
+                    is IntegerValue -> Mode.Decimal
+                    is FloatValue -> Mode.Float
+                    is CharValue -> Mode.Character
+                    else -> unreachable()
+                }
+            }
+
+            append(mode.str)
+        }
+
+        builder.append(javaFormatSpecifier.format(target.value))
+    }
+}
+
+open class GenericParser(val text: String) {
+    var cursor = 0
+
+    val done: Boolean
+        get() = cursor > text.lastIndex
+
+    val char: Char
+        get() = text[cursor]
+
+    fun consumeNumber(): Int? {
+        val pos = cursor
+
+        while (!done && char.isDigit())
+            cursor++
+
+        if (pos == cursor)
+            return null
+
+        return text.substring(pos, cursor).toIntOrNull() ?: run {
+            cursor = pos
+            null
+        }
+    }
+
+    fun consumeIf(char: Char): Boolean {
+        return if (matches(char)) {
+            cursor++
+            true
+        } else false
+    }
+
+    fun consumeIf(str: String): Boolean {
+        return if (matches(str)) {
+            cursor += str.length
+            true
+        } else false
+    }
+
+    fun peek(n: Int = 0) = text.getOrNull(cursor + n)
+
+    fun consume() = char.also { cursor++ }
+
+    fun matches(ch: Char): Boolean {
+        return !done && ch == char
+    }
+
+    fun matches(string: String): Boolean {
+        return text.substring(cursor).startsWith(string)
+    }
+}
+
+class Context(val arguments: List<Value>, private var nextValue: Int = 0) {
+    fun nextIndex() = nextValue++
+}
+
+class FormatSpecifierParser(specifier: String) : GenericParser(specifier) {
+    fun parse(context: Context): Specifier = with(Specifier()) {
+        index = consumeNumber() ?: context.nextIndex()
+
+        if (!consumeIf(':'))
+            return@with this
+
+        if ("<^>".contains(peek(1) ?: 'a')) {
+            check(char !in "{}") { "Malformed specifier \"$text\"" }
+            fillChar = consume()
+        }
+
+        alignment = when {
+            consumeIf('<') -> Specifier.Alignment.Left
+            consumeIf('^') -> Specifier.Alignment.Center
+            consumeIf('>') -> Specifier.Alignment.Right
+            else -> alignment
+        }
+
+        sign = when {
+            consumeIf('-') -> Specifier.Sign.OnlyIfNeeded
+            consumeIf('+') -> Specifier.Sign.Always
+            consumeIf(' ') -> Specifier.Sign.Reserved
+            else -> sign
+        }
+
+        if (consumeIf('#'))
+            alternative = true
+
+        if (consumeIf('0'))
+            zeroPad = true
+
+        val index = Ref<Int?>(null)
+        if (consumeReplacementField(index)) {
+            if (index.isNull)
+                index.set(context.nextIndex())
+
+            val widthValue = context.arguments.getOrNull(index.get()!!)
+            check(widthValue != null) {
+                "Width parameter refers to non-existent argument ${index.get()!!}"
+            }
+            check(widthValue is IntegerValue) {
+                "Expected integer for width argument at index ${index.get()!!}, found ${widthValue.typeName()}"
+            }
+            width = widthValue.value.toInt()
+        } else {
+            val num = consumeNumber()
+            if (num != null)
+                width = num
+        }
+
+        if (consumeIf('.')) {
+            if (consumeReplacementField(index)) {
+                if (index.isNull)
+                    index.set(context.nextIndex())
+
+                val precisionValue = context.arguments.getOrNull(index.get()!!)
+                check(precisionValue != null) {
+                    "Precision parameter refers to non-existent argument ${index.get()!!}"
+                }
+                check(precisionValue is IntegerValue) {
+                    "Expected integer for precision argument at index ${index.get()!!}, found ${precisionValue.typeName()}"
+                }
+                precision = precisionValue.value.toInt()
+            } else {
+                val num = consumeNumber()
+                if (num != null)
+                    precision = num
+            }
+        }
+
+        mode = when {
+            consumeIf('b') -> Specifier.Mode.Binary
+            consumeIf('B') -> Specifier.Mode.BinaryUppercase
+            consumeIf('d') -> Specifier.Mode.Decimal
+            consumeIf('o') -> Specifier.Mode.Octal
+            consumeIf('x') -> Specifier.Mode.Hexadecimal
+            consumeIf('X') -> Specifier.Mode.HexadecimalUppercase
+            consumeIf('c') -> Specifier.Mode.Character
+            consumeIf('s') -> Specifier.Mode.String
+            consumeIf('P') -> Specifier.Mode.Pointer
+            consumeIf('f') -> Specifier.Mode.Float
+            consumeIf('a') -> Specifier.Mode.HexFloat
+            consumeIf('A') -> Specifier.Mode.HexFloatUppercase
+            consumeIf("hex-dump") -> Specifier.Mode.HexDump
+            matches('}') -> Specifier.Mode.Default
+            !done -> error("Unknown format specifier '$char'")
+            else -> mode
+        }
+
+        check(consumeIf('}'))
+
+        check(done)
+
+        this
+    }
+
+    private fun consumeReplacementField(ref: Ref<Int?>): Boolean {
+        if (!consumeIf('{'))
+            return false
+
+        ref.set(consumeNumber())
+
+        check(consumeIf('}'))
+
+        return true
+    }
+}
+
+class FormatStringParser(formatString: String) : GenericParser(formatString) {
+    fun parse(): FormatString {
+        if (done)
+            return FormatString(listOf(""), emptyList())
+
+        val literals = mutableListOf<String>()
+        val specifiers = mutableListOf<String>()
+
+        while (true) {
+            literals.add(consumeLiteral())
+            val specifier = consumeSpecifier()
+
+            if (specifier == null) {
+                check(done) {
+                    "Expected specifier at offset $cursor"
+                }
+
+                return FormatString(literals, specifiers)
+            }
+
+            specifiers.add(specifier)
+        }
+    }
+
+    private fun consumeLiteral(): String {
+        val pos = cursor
+
+        while (!done) {
+            if (consumeIf("{{"))
+                continue
+
+            if (consumeIf("}}"))
+                continue
+
+            if (matches("{") || matches("}"))
+                return text.substring(pos, cursor)
+
+            cursor++
+        }
+
+        return text.substring(pos)
+    }
+
+    private fun consumeSpecifier(): String? {
+        require(!matches("}")) {
+            "Unexpected '}' at offset $cursor"
+        }
+
+        if (!consumeIf("{"))
+            return null
+
+        val pos = cursor
+
+        consumeNumber()
+
+        if (consumeIf(":")) {
+            var level = 1
+
+            while (level > 0) {
+                check(!done) {
+                    "Unexpected end of string in format specifier"
+                }
+
+                if (matches("{"))
+                    level++
+
+                if (matches("}"))
+                    level--
+
+                cursor++
+            }
+
+            return text.substring(pos, cursor)
+        }
+
+        check(consumeIf("}")) {
+            "Expected '}' at offset $cursor"
+        }
+
+        return ""
+    }
+}

--- a/src/main/kotlin/org/serenityos/jakt/folding/JaktBlockFoldingBuilder.kt
+++ b/src/main/kotlin/org/serenityos/jakt/folding/JaktBlockFoldingBuilder.kt
@@ -66,6 +66,11 @@ class JaktBlockFoldingBuilder : CustomFoldingBuilder() {
             descriptors += FoldingDescriptor(o, o.textRange)
         }
 
+        override fun visitMatchExpression(o: JaktMatchExpression) {
+            val body = o.matchBody ?: return
+            descriptors += FoldingDescriptor(o, TextRange(body.curlyOpen.startOffset, body.curlyClose.endOffset))
+        }
+
         private fun FoldingDescriptor(element: PsiElement) = FoldingDescriptor(element, element.textRange)
     }
 }

--- a/src/main/kotlin/org/serenityos/jakt/intentions/ImportNSDeclarationIntention.kt
+++ b/src/main/kotlin/org/serenityos/jakt/intentions/ImportNSDeclarationIntention.kt
@@ -8,8 +8,8 @@ import org.serenityos.jakt.psi.JaktPsiFactory
 import org.serenityos.jakt.psi.ancestorOfType
 import org.serenityos.jakt.psi.api.JaktImport
 import org.serenityos.jakt.psi.api.JaktPlainQualifier
-import org.serenityos.jakt.psi.declaration.aliasIdent
-import org.serenityos.jakt.psi.declaration.nameIdent
+import org.serenityos.jakt.psi.declaration.aliasString
+import org.serenityos.jakt.psi.declaration.targetString
 import org.serenityos.jakt.psi.reference.index
 
 class ImportNSDeclarationIntention : JaktIntention<ImportNSDeclarationIntention.Context>("Add import for member") {
@@ -27,7 +27,7 @@ class ImportNSDeclarationIntention : JaktIntention<ImportNSDeclarationIntention.
             return null
 
         val importStatement = file.getDeclarations().filterIsInstance<JaktImport>()
-            .find { it.nameIdent.text == resolvedFile.name.substringBefore(".jakt") }
+            .find { it.targetString == resolvedFile.name.substringBefore(".jakt") }
             ?: return null
 
         description = "Add import for \"${qualifier.text}\""
@@ -51,9 +51,9 @@ class ImportNSDeclarationIntention : JaktIntention<ImportNSDeclarationIntention.
         val newImportText = if (import.importBraceList?.importBraceEntryList?.isEmpty() != false) {
             buildString {
                 append("import ")
-                append(import.nameIdent.text)
+                append(import.targetString)
                 append(" ")
-                val alias = import.aliasIdent?.text
+                val alias = import.aliasString
                 if (alias != null)
                     append("as $alias ")
                 append("{ $newImportName }")

--- a/src/main/kotlin/org/serenityos/jakt/project/JaktProjectListener.kt
+++ b/src/main/kotlin/org/serenityos/jakt/project/JaktProjectListener.kt
@@ -2,10 +2,79 @@ package org.serenityos.jakt.project
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
+import org.serenityos.jakt.comptime.StringValue
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 
 class JaktProjectListener : ProjectManagerListener {
     override fun projectOpened(project: Project) {
         JaktProjectServiceImpl.copyPreludeFile(project)
         JaktUpdateNotification.showIfNecessary(project)
+
+        tryDetermineSystemTargetTriple()
+    }
+
+    private fun tryDetermineSystemTargetTriple() = thread {
+        if (targetTriple.get() != null)
+            return@thread
+
+        // First, try to get it from an installed compiler
+        val commands = setOf(
+            "clang++ -print-target-tuple",
+            "clang++14 -print-target-tuple",
+            "gcc -dumpmachine",
+            "g++ -dumpmachine",
+            "cc -dumpmachine",
+            "c++ -dumpmachine",
+        )
+
+        for (command in commands) {
+            try {
+                val process = Runtime.getRuntime().exec(command)
+                process.waitFor()
+                if (process.exitValue() != 0)
+                    continue
+                val text = process.inputStream.reader().readText().trim()
+                if ("-" in text) {
+                    targetTriple.set(StringValue(text))
+                    return@thread
+                }
+            } catch (e: Throwable) {
+                // ignore
+            }
+        }
+
+        // If that doesn't work, then try to pick an appropriate triple from the
+        // environment information. This tries to model what Jakt does
+        val name = System.getProperty("os.name")?.lowercase()
+
+        if (name == null) {
+            // Give up
+            targetTriple.set(StringValue("unknown-unknown-unknown-unknown"))
+            return@thread
+        }
+
+        val is64Bit =
+            System.getProperty("os.arch")?.contains("64") == true ||
+            System.getProperty("java.vm.name")?.contains("64") == true ||
+            System.getProperty("sun.management.compiler")?.contains("64") == true ||
+            System.getProperty("sun.arch.data.model")?.contains("64") == true
+
+        val tripleGuess = when {
+            "win" in name -> if (is64Bit) "i686-pc-windows-msvc" else "x86_64-pc-windows-msvc"
+            "linux" in name -> "x86_64-pc-linux-gnu"
+            "bsd" in name -> "x86_64-pc-bsd-unknown"
+            "mac" in name || "darwin" in name -> "x86_64-apple-darwin-unknown"
+            "unix" in name -> "x86_64-pc-unix-unknown"
+            else -> "unknown-unknown-unknown-unknown"
+        }
+
+        targetTriple.set(StringValue(tripleGuess))
+    }
+
+    companion object {
+        // The system triple (ex: "x64_64-pc-linux-gnu"). This is used in comptime
+        // execution to populate the ___jakt_get_target_triple_string function
+        val targetTriple = AtomicReference<StringValue>()
     }
 }

--- a/src/main/kotlin/org/serenityos/jakt/psi/caching/JaktCache.kt
+++ b/src/main/kotlin/org/serenityos/jakt/psi/caching/JaktCache.kt
@@ -55,6 +55,8 @@ abstract class JaktCache(project: Project) : Disposable {
 
 class JaktResolveCache(project: Project) : JaktCache(project)
 class JaktTypeCache(project: Project) : JaktCache(project)
+class JaktComptimeCache(project: Project) : JaktCache(project)
 
 fun PsiElement.resolveCache() = project.service<JaktResolveCache>()
 fun PsiElement.typeCache() = project.service<JaktTypeCache>()
+fun PsiElement.comptimeCache() = project.service<JaktComptimeCache>()

--- a/src/main/kotlin/org/serenityos/jakt/psi/caching/JaktCache.kt
+++ b/src/main/kotlin/org/serenityos/jakt/psi/caching/JaktCache.kt
@@ -39,6 +39,17 @@ abstract class JaktCache(project: Project) : Disposable {
         return map.getOrPut(key) { resolver(key) } as V
     }
 
+    @Suppress("UNCHECKED_CAST")
+    fun <K : PsiElement, V : Any> resolve(key: K): V? {
+        ProgressManager.checkCanceled()
+        return getCacheFor(key)[key] as V?
+    }
+
+    fun <K : PsiElement, V : Any> set(key: K, value: V) {
+        ProgressManager.checkCanceled()
+        getCacheFor(key)[key] = value
+    }
+
     private fun getCacheFor(element: PsiElement): ConcurrentMap<PsiElement, Any> {
         val owner = element.modificationBoundary
 

--- a/src/main/kotlin/org/serenityos/jakt/psi/declaration/JaktImportMixin.kt
+++ b/src/main/kotlin/org/serenityos/jakt/psi/declaration/JaktImportMixin.kt
@@ -6,7 +6,7 @@ import org.serenityos.jakt.JaktFile
 import org.serenityos.jakt.JaktTypes
 import org.serenityos.jakt.comptime.ArrayValue
 import org.serenityos.jakt.comptime.StringValue
-import org.serenityos.jakt.comptime.comptimeValue
+import org.serenityos.jakt.comptime.performComptimeEvaluation
 import org.serenityos.jakt.project.jaktProject
 import org.serenityos.jakt.psi.api.JaktImport
 import org.serenityos.jakt.psi.caching.typeCache
@@ -33,7 +33,7 @@ val JaktImport.targetString: String
     get() = typeCache().resolveWithCaching(this) {
         importTarget.identifier?.let { return@resolveWithCaching it.text }
 
-        when (val comptimeValue = importTarget.callExpression?.comptimeValue) {
+        when (val comptimeValue = importTarget.callExpression?.performComptimeEvaluation()?.value) {
             is StringValue -> comptimeValue.value
             is ArrayValue -> {
                 val project = jaktProject

--- a/src/main/kotlin/org/serenityos/jakt/psi/declaration/JaktImportMixin.kt
+++ b/src/main/kotlin/org/serenityos/jakt/psi/declaration/JaktImportMixin.kt
@@ -1,12 +1,15 @@
 package org.serenityos.jakt.psi.declaration
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.serenityos.jakt.JaktFile
 import org.serenityos.jakt.JaktTypes
+import org.serenityos.jakt.comptime.ArrayValue
+import org.serenityos.jakt.comptime.StringValue
+import org.serenityos.jakt.comptime.comptimeValue
 import org.serenityos.jakt.project.jaktProject
 import org.serenityos.jakt.psi.api.JaktImport
+import org.serenityos.jakt.psi.caching.typeCache
 import org.serenityos.jakt.psi.findChildrenOfType
 import org.serenityos.jakt.psi.named.JaktStubbedNamedElement
 import org.serenityos.jakt.psi.reference.singleRef
@@ -24,11 +27,29 @@ abstract class JaktImportMixin : JaktStubbedNamedElement<JaktImportStub>, JaktIm
     override fun getReference() = singleRef { resolveFile() }
 }
 
-val JaktImport.nameIdent: PsiElement
-    get() = originalElement.findChildrenOfType(JaktTypes.IDENTIFIER).first()
+// Note that JaktImport doesn't have a type, and thus doesn't use the typeCache normally. So we
+// can repurpose it to save this string
+val JaktImport.targetString: String
+    get() = typeCache().resolveWithCaching(this) {
+        importTarget.identifier?.let { return@resolveWithCaching it.text }
 
-val JaktImport.aliasIdent: PsiElement?
-    get() = originalElement.findChildrenOfType(JaktTypes.IDENTIFIER).getOrNull(1)
+        when (val comptimeValue = importTarget.callExpression?.comptimeValue) {
+            is StringValue -> comptimeValue.value
+            is ArrayValue -> {
+                val project = jaktProject
+                val containingFile = containingFile.originalFile.virtualFile
+                for (value in comptimeValue.values) {
+                    if (value is StringValue && project.resolveImportedFile(containingFile, value.value) != null)
+                        return@resolveWithCaching value.value
+                }
+                "__UNKNOWN"
+            }
+            else -> "__UNKNOWN"
+        }
+    }
+
+val JaktImport.aliasString: String?
+    get() = originalElement.findChildrenOfType(JaktTypes.IDENTIFIER).firstOrNull()?.text
 
 fun JaktImport.resolveFile(): JaktFile? =
-    jaktProject.resolveImportedFile(containingFile.originalFile.virtualFile, nameIdent.text)
+    jaktProject.resolveImportedFile(containingFile.originalFile.virtualFile, targetString)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -170,6 +170,7 @@
         <projectService serviceImplementation="org.serenityos.jakt.psi.caching.JaktPsiManager" />
         <projectService serviceImplementation="org.serenityos.jakt.psi.caching.JaktResolveCache" />
         <projectService serviceImplementation="org.serenityos.jakt.psi.caching.JaktTypeCache" />
+        <projectService serviceImplementation="org.serenityos.jakt.psi.caching.JaktComptimeCache" />
         <projectConfigurable
                 instance="org.serenityos.jakt.project.JaktLanguageProjectConfigurable"
                 groupId="language"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -221,4 +221,12 @@
         </intentionAction>
 
     </extensions>
+    <actions>
+        <action id="org.serenityos.jakt.comptime.ShowComptimeValueAction"
+                class="org.serenityos.jakt.comptime.ShowComptimeValueAction"
+                text="Show Jakt Comptime Value"
+                description="Display the comptime value of the hovered expression, if possible">
+            <add-to-group group-id="EditorPopupMenu3" anchor="last"/>
+        </action>
+    </actions>
 </idea-plugin>

--- a/src/main/resources/grammar/Jakt.bnf
+++ b/src/main/resources/grammar/Jakt.bnf
@@ -102,12 +102,13 @@ upper NamespaceDeclaration ::= NAMESPACE_KEYWORD IDENTIFIER NamespaceBody {
 NamespaceBody ::= CURLY_OPEN NL TopLevelDefinitionList? NL CURLY_CLOSE
 
 // Import Statement
-upper Import ::= IMPORT_KEYWORD !EXTERN_KEYWORD IDENTIFIER ImportAs? ImportBraceList? {
+upper Import ::= IMPORT_KEYWORD !EXTERN_KEYWORD ImportTarget ImportAs? ImportBraceList? {
     implements="org.serenityos.jakt.psi.declaration.JaktDeclaration"
     mixin="org.serenityos.jakt.psi.declaration.JaktImportMixin"
     stubClass="org.serenityos.jakt.stubs.JaktImportStub"
     elementTypeFactory="org.serenityos.jakt.stubs.JaktStubFactoryKt.jaktStubFactory"
 }
+ImportTarget ::= IDENTIFIER !PAREN_OPEN | CallExpression
 private ImportAs ::= KEYWORD_AS IDENTIFIER
 ImportBraceList ::= CURLY_OPEN NL <<commaOrEolList ImportBraceEntry>>? NL CURLY_CLOSE
 ImportBraceEntry ::= IDENTIFIER {

--- a/src/test/kotlin/org/serenityos/jakt/JaktBaseTest.kt
+++ b/src/test/kotlin/org/serenityos/jakt/JaktBaseTest.kt
@@ -27,9 +27,8 @@ abstract class JaktBaseTest : BasePlatformTestCase() {
         tagElements.forEach { comment ->
             val matches = tagRegex.findAll(comment.text).toList()
 
-            check(matches.isNotEmpty()) {
-                "Comment in test with no tags"
-            }
+            if (matches.isEmpty())
+                return@forEach
 
             for (match in matches) {
                 val group = match.groups[1] ?: error("Invalid tag comment")
@@ -50,6 +49,10 @@ abstract class JaktBaseTest : BasePlatformTestCase() {
                     ::mutableListOf
                 ).add(myFixture.file.findElementAt(elementOffset)!!)
             }
+        }
+
+        check(taggedElements.isNotEmpty()) {
+            "No tagged elements found"
         }
 
         return taggedElements

--- a/src/test/kotlin/org/serenityos/jakt/comptime/JaktBasicComptimeTest.kt
+++ b/src/test/kotlin/org/serenityos/jakt/comptime/JaktBasicComptimeTest.kt
@@ -1,0 +1,18 @@
+package org.serenityos.jakt.comptime
+
+class JaktBasicComptimeTest : JaktComptimeTest() {
+    fun `test bitwise operators`() = doStdoutTest("""
+        comptime bitwise() {
+            if (((0x123 ^ 0x456) << 12) | (0x789 & 0xabc)) == 0x575288 {
+                print("PASS")
+            } else {
+                print("FAIL")
+            }
+        }
+
+        function main() {
+            bitwise()
+          //^T
+        }
+    """.trimIndent(), "PASS")
+}

--- a/src/test/kotlin/org/serenityos/jakt/comptime/JaktComptimeTest.kt
+++ b/src/test/kotlin/org/serenityos/jakt/comptime/JaktComptimeTest.kt
@@ -1,0 +1,41 @@
+package org.serenityos.jakt.comptime
+
+import org.intellij.lang.annotations.Language
+import org.serenityos.jakt.JaktBaseTest
+
+abstract class JaktComptimeTest : JaktBaseTest() {
+    protected fun doTest(@Language("Jakt") text: String, test: (Interpreter.Result) -> Unit) {
+        setupFor(text)
+
+        val taggedElements = extractTaggedElements()
+        val elements = taggedElements["T"]
+        check(!elements.isNullOrEmpty()) {
+            "No tagged elements found"
+        }
+
+        check(elements.size == 1) {
+            "More than one tagged element found"
+        }
+
+        val targetElement = elements.single().getComptimeTargetElement()
+        check(targetElement != null) {
+            "Element cannot be evaluated at comptime"
+        }
+
+        test(Interpreter.evaluate(targetElement))
+    }
+
+    protected fun doStdoutTest(@Language("Jakt") text: String, expectedStdout: String) = doTest(text) {
+        check(expectedStdout == it.stdout)
+    }
+
+    protected fun doStderrTest(@Language("Jakt") text: String, expectedStderr: String) = doTest(text) {
+        check(expectedStderr == it.stderr)
+    }
+
+    protected fun doValueTest(@Language("Jakt") text: String, expectedValue: Value) = doTest(text) {
+        check(it.value == expectedValue) {
+            "Expected $expectedValue, found ${it.value}"
+        }
+    }
+}

--- a/src/test/kotlin/org/serenityos/jakt/comptime/JaktStringComptimeTest.kt
+++ b/src/test/kotlin/org/serenityos/jakt/comptime/JaktStringComptimeTest.kt
@@ -1,0 +1,53 @@
+package org.serenityos.jakt.comptime
+
+class JaktStringComptimeTest : JaktComptimeTest() {
+    fun `test string methods`() = doStdoutTest("""
+        comptime empty() throws => "".is_empty()
+        comptime length() throws => "a string of length 21".length()
+        comptime substring() throws => "abcdef".substring(start: 1, length: 3)
+        comptime hash() throws => "well, hello friends".hash()
+        comptime number() throws => String::number(123)
+        comptime to_uint() throws => "123".to_uint()
+        comptime to_int() throws => "-456".to_int()
+        comptime is_whitespace() throws => " ".is_whitespace() and not "abc".is_whitespace()
+        comptime contains() throws => "abcdef".contains("bcd")
+        comptime replace() throws => "well, hiya friends".replace(replace: "hiya", with: "hello")
+        comptime byte_at() throws => "AAAA".byte_at(3)
+        comptime starts_with() throws => "abcdef".starts_with("abc")
+        comptime ends_with() throws => "abcdef".ends_with("def")
+        comptime repeated() throws => String::repeated(character: 'A', count: 5)
+        comptime split() throws => "a;b;c".split(';')
+        
+        comptime test() throws {
+            mut success = empty()
+            success = success and length() == 21
+            success = success and substring() == "bcd"
+            success = success and hash() == "well, hello friends".hash()
+            success = success and number() == "123"
+            success = success and to_uint()! == 123u32
+            success = success and to_int()! == -456i32
+            success = success and is_whitespace()
+            success = success and contains()
+            success = success and replace() == "well, hello friends"
+            success = success and byte_at() == 0x41
+            success = success and starts_with()
+            success = success and ends_with()
+            success = success and repeated() == "AAAAA"
+            let parts = split()
+            success = success and parts[0] == "a"
+            success = success and parts[1] == "b"
+            success = success and parts[2] == "c"
+
+            if success {
+                print("PASS")
+            } else {
+                print("FAIL")
+            }
+        }
+        
+        function main() {
+            test()
+          //^T
+        }
+    """, "PASS")
+}


### PR DESCRIPTION
This can process most expressions and statements. The primary goal is to be able to resolve comptime calls in import statements so that the IDE can continue to provide the user with a good experience, however this also comes with the benefit of allowing the user to evaluate arbitrary comptime expression straight from their IDE:

<details>
<summary>Demo of in-IDE comptime evaluation</summary>
Code:

```
comptime get_names() throws -> [String] {
    mut builder = StringBuilder::create()
    builder.append(b'f')
    builder.append_string("ile2")
    println("Hello.......")
    println("....world!")
    eprintln("oops, some error occurred")
    return ["file1", builder.to_string()]
}

function main() {
    let a = get_names()
}
```
![context menu](https://i.imgur.com/QO0GFAT.png)
![results](https://i.imgur.com/z5B8wNf.png)
</details>

TODO:
  - [ ] Struct support 
  - [ ] Match expressions
  - [ ] Tracking integer/float types (instead of just always using `i64`/`f64`)
  - [ ] Styling the element in the popup that appears when the user evaluates a comptime element. This will require some architectural work in the renderer
  - [ ] IDE debugging support? It is absolutely possible, just a matter of figuring it out